### PR TITLE
Feature/subdomain improvements

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -508,7 +508,9 @@ func (p *OAuthProxy) GetRedirect(req *http.Request) (redirect string, err error)
 			if p.CookieSecure {
 				scheme = httpsScheme
 			}
-			host = scheme + "://" + req.Host
+			if p.IsValidRedirect(scheme + "://" + req.Host) {
+				host = scheme + "://" + req.Host
+			}
 		}
 
 		if strings.HasPrefix(redirect, p.ProxyPrefix) {

--- a/pkg/apis/options/options.go
+++ b/pkg/apis/options/options.go
@@ -20,21 +20,22 @@ type SignatureData struct {
 // Options holds Configuration Options that can be set by Command Line Flag,
 // or Config File
 type Options struct {
-	ProxyPrefix        string   `flag:"proxy-prefix" cfg:"proxy_prefix"`
-	PingPath           string   `flag:"ping-path" cfg:"ping_path"`
-	PingUserAgent      string   `flag:"ping-user-agent" cfg:"ping_user_agent"`
-	HTTPAddress        string   `flag:"http-address" cfg:"http_address"`
-	HTTPSAddress       string   `flag:"https-address" cfg:"https_address"`
-	ReverseProxy       bool     `flag:"reverse-proxy" cfg:"reverse_proxy"`
-	RealClientIPHeader string   `flag:"real-client-ip-header" cfg:"real_client_ip_header"`
-	TrustedIPs         []string `flag:"trusted-ip" cfg:"trusted_ips"`
-	ForceHTTPS         bool     `flag:"force-https" cfg:"force_https"`
-	RawRedirectURL     string   `flag:"redirect-url" cfg:"redirect_url"`
-	ClientID           string   `flag:"client-id" cfg:"client_id"`
-	ClientSecret       string   `flag:"client-secret" cfg:"client_secret"`
-	ClientSecretFile   string   `flag:"client-secret-file" cfg:"client_secret_file"`
-	TLSCertFile        string   `flag:"tls-cert-file" cfg:"tls_cert_file"`
-	TLSKeyFile         string   `flag:"tls-key-file" cfg:"tls_key_file"`
+	ProxyPrefix          string   `flag:"proxy-prefix" cfg:"proxy_prefix"`
+	PingPath             string   `flag:"ping-path" cfg:"ping_path"`
+	PingUserAgent        string   `flag:"ping-user-agent" cfg:"ping_user_agent"`
+	HTTPAddress          string   `flag:"http-address" cfg:"http_address"`
+	HTTPSAddress         string   `flag:"https-address" cfg:"https_address"`
+	ReverseProxy         bool     `flag:"reverse-proxy" cfg:"reverse_proxy"`
+	RealClientIPHeader   string   `flag:"real-client-ip-header" cfg:"real_client_ip_header"`
+	TrustedIPs           []string `flag:"trusted-ip" cfg:"trusted_ips"`
+	ForceHTTPS           bool     `flag:"force-https" cfg:"force_https"`
+	RawRedirectURL       string   `flag:"redirect-url" cfg:"redirect_url"`
+	ClientID             string   `flag:"client-id" cfg:"client_id"`
+	ClientSecret         string   `flag:"client-secret" cfg:"client_secret"`
+	ClientSecretFile     string   `flag:"client-secret-file" cfg:"client_secret_file"`
+	TLSCertFile          string   `flag:"tls-cert-file" cfg:"tls_cert_file"`
+	TLSKeyFile           string   `flag:"tls-key-file" cfg:"tls_key_file"`
+	RedirectPreserveHost bool     `flag:"redirect-preserve-host" cfg:"redirect_preserve_host"`
 
 	AuthenticatedEmailsFile  string   `flag:"authenticated-emails-file" cfg:"authenticated_emails_file"`
 	KeycloakGroup            string   `flag:"keycloak-group" cfg:"keycloak_group"`
@@ -167,6 +168,7 @@ func NewOptions() *Options {
 		InsecureOIDCAllowUnverifiedEmail: false,
 		SkipOIDCDiscovery:                false,
 		Logging:                          loggingDefaults(),
+		RedirectPreserveHost:             false,
 	}
 }
 
@@ -183,6 +185,7 @@ func NewFlagSet() *pflag.FlagSet {
 	flagSet.String("tls-cert-file", "", "path to certificate file")
 	flagSet.String("tls-key-file", "", "path to private key file")
 	flagSet.String("redirect-url", "", "the OAuth Redirect URL. ie: \"https://internalapp.yourcompany.com/oauth2/callback\"")
+	flagSet.Bool("redirect-preserve-host", false, "Preserve host in redirect after authentication")
 	flagSet.Bool("set-xauthrequest", false, "set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode)")
 	flagSet.Bool("pass-basic-auth", true, "pass HTTP Basic Auth, X-Forwarded-User and X-Forwarded-Email information to upstream")
 	flagSet.Bool("set-basic-auth", false, "set HTTP Basic Auth information in response (useful in Nginx auth_request mode)")

--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -57,10 +57,11 @@ func MakeCookieFromOptions(req *http.Request, name string, value string, cookieO
 // GetCookieDomain returns the correct cookie domain given a list of domains
 // by checking the X-Fowarded-Host and host header of an an http request
 func GetCookieDomain(req *http.Request, cookieDomains []string) string {
-	host := util.GetRequestHost(req)
-	for _, domain := range cookieDomains {
-		if strings.HasSuffix(host, domain) {
-			return domain
+	if host, _, err := net.SplitHostPort(util.GetRequestHost(req)); err == nil {
+		for _, domain := range cookieDomains {
+			if strings.HasSuffix(host, domain) {
+				return domain
+			}
 		}
 	}
 	return ""

--- a/pkg/cookies/cookies.go
+++ b/pkg/cookies/cookies.go
@@ -57,11 +57,14 @@ func MakeCookieFromOptions(req *http.Request, name string, value string, cookieO
 // GetCookieDomain returns the correct cookie domain given a list of domains
 // by checking the X-Fowarded-Host and host header of an an http request
 func GetCookieDomain(req *http.Request, cookieDomains []string) string {
-	if host, _, err := net.SplitHostPort(util.GetRequestHost(req)); err == nil {
-		for _, domain := range cookieDomains {
-			if strings.HasSuffix(host, domain) {
-				return domain
-			}
+	host := util.GetRequestHost(req)
+	// Attempt to split host and port if needed
+	splitHost, _, err := net.SplitHostPort(host); if err == nil {
+		host = splitHost
+	}
+	for _, domain := range cookieDomains {
+		if strings.HasSuffix(host, domain) {
+			return domain
 		}
 	}
 	return ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for preserving host in redirect used after authentication. In addition, strip the port from the host when validating the cookie domain list.

## Motivation and Context

This host preservation change addresses an issue where a single instance of the proxy can't be deployed for use with multiple subdomains. This is useful if the application does work with purely path based routing.

Stripping the port from the host when validating against the domain addresses an issue where the proxy is deployed using a non-standard port and therefore fails the validation. 

## How Has This Been Tested?

The changes have been tested locally with NGINX running behind the proxy to handle the host-based routing. This was accomplished using the local host file to create different "subdomains" to ensure the proxy is able to authenticate and redirect the client back to the original destination on the correct host. Using the config to toggle the feature, has been tested both enabled and disabled, resulting in the desired behaviour.

Further testing has been done in a Kubernetes cluster deployed on EKS, once again using NGINX for host based routing. This also demonstrated the port stripping continuing the work with standard HTTP/S ports.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.

